### PR TITLE
Disable opening hours layer

### DIFF
--- a/app/configurations/config.mfdz.js
+++ b/app/configurations/config.mfdz.js
@@ -108,7 +108,7 @@ export default configMerger(walttiConfig, {
   },
 
   covid19: {
-    show: true,
+    show: false,
     smallIconZoom: 17,
     minZoom: 15,
   },


### PR DESCRIPTION
## Proposed Changes
Since Ca Reste Ouvert will be closing operations on 30th September, we won't have the necessary data and so need to disable the Covid19 opening hours layer.